### PR TITLE
Build and deploy website from Github actions

### DIFF
--- a/.github/actions/build_website/action.yml
+++ b/.github/actions/build_website/action.yml
@@ -1,0 +1,43 @@
+name: Build 4C website
+description: Builds the 4C website for a specific URL and base path
+inputs:
+  website-root-path:
+    description: Root path of the website
+    required: false
+    default: ""
+  website-url:
+    description: URL of the website
+    required: false
+    default: https://www.4c-multiphysics.org
+  build-dir:
+    description: Directory where the website is built
+    required: false
+    default: website
+runs:
+  using: composite
+  steps:
+    - name: Set up Ruby
+      shell: bash
+      run: |
+        cd $GITHUB_WORKSPACE
+        gem install bundler
+        bundle config set --local path 'vendor/bundle'
+        bundle install
+    - name: Configure website
+      shell: bash
+      run: |
+        cd $GITHUB_WORKSPACE
+        echo "baseurl: $WEBSITE_ROOT_PATH" > config.yml
+        echo "url: $WEBSITE_URL" >> config.yml
+      env:
+        WEBSITE_ROOT_PATH: ${{ inputs.website-root-path }}
+        WEBSITE_URL: ${{ inputs.website-url }}
+    - name: Build website
+      shell: bash
+      run: |
+        cd $GITHUB_WORKSPACE
+        mkdir -p $BUILD_DIR
+        bundle exec jekyll build -d $BUILD_DIR --config _config.yml,config.yml
+        cp .htaccess $BUILD_DIR
+      env:
+        BUILD_DIR: ${{ inputs.build-dir }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: build
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: ruby:3.3
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build 4C website
+        uses: ./.github/actions/build_website
+        with:
+          website-root-path: ''
+          website-url: https://www.4c-multiphysics.org
+          build-dir: ${{ github.workspace }}/website
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
+        with:
+          name: 4C-website
+          path: |
+            ${{ github.workspace }}/website/
+          retention-days: 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,41 @@
+name: deploy
+
+on:
+  workflow_run:
+    workflows: [build]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-24.04
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - uses: dawidd6/action-download-artifact@v6
+        with:
+          workflow: build.yml
+          name: 4C-website
+          path: ${{ github.workspace }}/website
+          branch: ${{ github.event.repository.default_branch }}
+          github_token: ${{ secrets.FOUR_C_WEBSITE_GITHUB_TOKEN }}
+      - name: Deploy webiste to 4c-multiphysics.org
+        shell: bash
+        run: |
+          sudo apt-get install -y lftp
+          cd $LOCAL_DIR
+          lftp -u $USERNAME --env-password $SERVER -e "set ftp:ssl-protect-data true; set ssl:verify-certificate false; cd $SERVER_DIR; mirror -R --delete . .; exit"
+        env:  
+          SERVER: ${{ vars.FOUR_C_WEBSITE_SERVER }}
+          USERNAME: ${{ vars.FOUR_C_WEBSITE_USERNAME }}
+          LFTP_PASSWORD: ${{ secrets.FOUR_C_WEBSITE_PASSWORD }}
+          SERVER_DIR: ${{ vars.FOUR_C_WEBSITE_BASE_PATH }}
+          LOCAL_DIR: ${{ github.workspace }}/website/
+            


### PR DESCRIPTION
This PR enables publishing our website from Github.

Note, currently, it is not possible to preview the website as it was in the case on Gitlab. Maybe, Github will add at some point in the future a feature so that we can savely do it.

@queens-py