### PR TITLE
Fix inconsistent spelling of multiphysics

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -4,7 +4,7 @@ bodyClass: "page-home"
 ---
 
 <div class="container">
-    <h1 class="title">4C: A Comprehensive Multi-Physics Simulation Framework</h1>
+    <h1 class="title">4C: A Comprehensive Multiphysics Simulation Framework</h1>
 </div>
 
 <div class="intro">

--- a/capabilities.md
+++ b/capabilities.md
@@ -22,7 +22,7 @@ For flow problems, 4C comes with an incompressible Navier–Stokes solver (inclu
 For biomedical applications, reduced order models for flow in arteries or airways are available alongside suitable Windkessel models. 
 Finally, solvers for transport of scalar fields such as heat or chemical concentrations are available.
 
-With the intent to study multi-physics phenomena, 4C builds upon its single-field solvers to implement partitioned and monolithic multi-physics solvers for surface- and volume-coupled problems. 
+With the intent to study multiphysics phenomena, 4C builds upon its single-field solvers to implement partitioned and monolithic multiphysics solvers for surface- and volume-coupled problems. 
 In surface coupling, existing capabilities from the solid and structural mechanics module are coupled to incompressible fluid flow, 
 resulting in partitioned and monolithic FSI solvers using an arbitrary Lagrangean-Eulerian (ALE) description for deforming fluid domains with scalable multi-level solvers, 
 monolithic solvers for fixed-grid FSI based on CutFEM, or partitioned approaches for fluid-beam interaction. In volume-coupling, 

--- a/history.md
+++ b/history.md
@@ -11,7 +11,7 @@ The development of 4C arose from the need to tackle challenging research questio
 for ordinary and partial differential equations and to advance complex models for real-world applications, 
 all based on a proper theoretical foundation and with verified and state-of-the-art methods and software implementations. 
 Since suitable tools are often not available either in commercial or in other (academic) research codes, 
-we want to close this gap by developing 4C, a comprehensive multi-physics simulation framework. 
+we want to close this gap by developing 4C, a comprehensive multiphysics simulation framework. 
 
 4C originated in the 2000s at the Institute for Computational Mechanics of the Technical University of Munich, 
 where the software has been developed under the name BACI. 

--- a/publications.md
+++ b/publications.md
@@ -11,7 +11,7 @@ permalink: "/publications/"
 Whenever you mention 4C in some sort of scientific document/publication/presentation, please cite 4C as follows:
 
 ```
-4C: A Comprehensive Multi-Physics Simulation Framework, https://www.4c-multiphysics.org
+4C: A Comprehensive Multiphysics Simulation Framework, https://www.4c-multiphysics.org
 ```
 
 You could use the following BibTeX entry:
@@ -19,7 +19,7 @@ You could use the following BibTeX entry:
 ```bibtex
 @misc{4C,
   author       = {4C},
-  title        = {4C: A {C}omprehensive {M}ulti-{P}hysics {S}imulation {F}ramework},
+  title        = {4C: A {C}omprehensive {M}ultiphysics {S}imulation {F}ramework},
   howpublished = {\url{https://www.4c-multiphysics.org}},
   year         = {YEAR},
   note         = {Accessed: DATE}


### PR DESCRIPTION
I replaced all occurrences of multi-physics that `grep` found in the website directory.

Closes #13 