### PR TITLE
Fix authors of steinbrecher2025

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -1,5 +1,5 @@
 @article{Steinbrecher2025,
-    author = {Steinbrecher, Ivo; Hagmeyer, Nora; Meier, Christoph; Popp, Alexander},
+    author = {Steinbrecher, Ivo and Hagmeyer, Nora and Meier, Christoph and Popp, Alexander},
     title = {A consistent mixed-dimensional coupling approach for 1D Cosserat beams and 2D surfaces in 3D space},
     journal = {Computational Mechanics},
     year = {2025},


### PR DESCRIPTION
Currently, the authors of the latest publication by @isteinbrecher are not showing up on the website (see screenshot below). This is an attempt to fix that by adapting the formatting to the way it is done for other publications.

<img width="901" height="345" alt="Screenshot 2025-08-17 at 11 30 20" src="https://github.com/user-attachments/assets/8df78e19-2bfa-41b0-aaf1-7c2eb4c4f4db" />
