### PR TITLE
Update readme and .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ _site
 .sass-cache
 .idea/
 .jekyll-metadata
+node_modules/
 public/
 vendor/
 .bundle/

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To propose a change to the website, follow these steps:
 
 1. Open an issue to announce and discuss upcoming changes (optional, but recommended).
 1. Fork and clone the repository.
-1. Run `./<source_dir>/set_up_dev_env.sh` to set up the development environment and pre-commit hooks.
+1. Run `./<source_dir>/utilities/set_up_dev_env.sh` to set up the development environment and pre-commit hooks.
 1. Create a feature branch, where you will make any change.
 1. To inspect your changes, navigate into the website source code directory and
    1. for setup: run `bundle install`


### PR DESCRIPTION
I realized that the path of the `set_up_dev_env.sh` script was not correctly mentioned in the README.

Moreover, the pre-commit hooks create a `node_modules` directory, which I added to the .gitignore because its contents are not of interest to this repo.