### PR TITLE
Add link to stomach paper

### DIFF
--- a/_data/examples.json
+++ b/_data/examples.json
@@ -19,7 +19,7 @@
       "height": "auto"
     },
     "featured": false,
-    "description": "Peristaltic contractions of human stomach, modelled using monolithic electro-mechanical coupling",
+    "description": "Peristaltic contractions of the human stomach, modelled using partitioned electro-mechanical coupling",
     "link": "https://doi.org/10.1016/j.cma.2025.118549",
     "author": "Maire Henke"
   },

--- a/_data/examples.json
+++ b/_data/examples.json
@@ -20,6 +20,7 @@
     },
     "featured": false,
     "description": "Peristaltic contractions of human stomach, modelled using monolithic electro-mechanical coupling",
+    "link": "https://doi.org/10.1016/j.cma.2025.118549",
     "author": "Maire Henke"
   },
   {


### PR DESCRIPTION
Add a project link for the “Multiphysics: electro-mechanical simulation” example on the capabilities page.

This update adds the DOI-based paper link for the stomach peristaltic contractions example so the corresponding entry displays a “Project link” on the website.